### PR TITLE
List individual builders when notifying about posted bill

### DIFF
--- a/src/accountManager.ts
+++ b/src/accountManager.ts
@@ -3,6 +3,10 @@ import { BillingContract } from "./billingContract";
 import { Slack } from "./notify";
 import { ethers } from "ethers";
 import { DraftResults, LatestBillingStatus, PaymentStatus } from "./types";
+<<<<<<< HEAD
+=======
+import { stat } from "fs";
+>>>>>>> 2cf22fd (Make draft execution optional)
 
 const TEN_ETH = ethers.parseEther("1");
 
@@ -68,6 +72,7 @@ export class AccountManager {
     }
   }
 
+<<<<<<< HEAD
   async paymentStatusPost(
     paymentStatuses: LatestBillingStatus[],
   ): Promise<void> {
@@ -81,6 +86,17 @@ export class AccountManager {
     }
     if (messages.length == 1) {
       messages.push("All builders paid");
+=======
+  async paymentStatusPost(paymentStatuses: LatestBillingStatus[]): Promise<void> {
+    let messages = ["MEVBlocker builder payment status update:"];
+    for (let paymentStatus of paymentStatuses) {
+      if (paymentStatus.status !== PaymentStatus.PAID) {
+        messages.push(`${paymentStatus.account} was supposed to pay ${paymentStatus.billedAmount} but paid ${paymentStatus.paidAmount}`);
+      }
+    }
+    if (messages.length == 1) {
+      messages.push("All builders paid")
+>>>>>>> 2cf22fd (Make draft execution optional)
     }
     await this.slack.post(messages.join("\n"));
   }

--- a/src/accountManager.ts
+++ b/src/accountManager.ts
@@ -3,10 +3,6 @@ import { BillingContract } from "./billingContract";
 import { Slack } from "./notify";
 import { ethers } from "ethers";
 import { DraftResults, LatestBillingStatus, PaymentStatus } from "./types";
-<<<<<<< HEAD
-=======
-import { stat } from "fs";
->>>>>>> 2cf22fd (Make draft execution optional)
 
 const TEN_ETH = ethers.parseEther("1");
 
@@ -72,7 +68,6 @@ export class AccountManager {
     }
   }
 
-<<<<<<< HEAD
   async paymentStatusPost(
     paymentStatuses: LatestBillingStatus[],
   ): Promise<void> {
@@ -86,17 +81,6 @@ export class AccountManager {
     }
     if (messages.length == 1) {
       messages.push("All builders paid");
-=======
-  async paymentStatusPost(paymentStatuses: LatestBillingStatus[]): Promise<void> {
-    let messages = ["MEVBlocker builder payment status update:"];
-    for (let paymentStatus of paymentStatuses) {
-      if (paymentStatus.status !== PaymentStatus.PAID) {
-        messages.push(`${paymentStatus.account} was supposed to pay ${paymentStatus.billedAmount} but paid ${paymentStatus.paidAmount}`);
-      }
-    }
-    if (messages.length == 1) {
-      messages.push("All builders paid")
->>>>>>> 2cf22fd (Make draft execution optional)
     }
     await this.slack.post(messages.join("\n"));
   }

--- a/src/accountManager.ts
+++ b/src/accountManager.ts
@@ -50,9 +50,16 @@ export class AccountManager {
     const billingResults = await this.dataFetcher.getBillingData(today);
     const txHash =
       await this.billingContract.updatePaymentDetails(billingResults);
-    await this.slack.post(
-      `MEV Billing ran successfully: ${this.txLink(txHash)}`,
-    );
+
+    let messages = [`MEV Billing ran successfully: ${this.txLink(txHash)}`];
+    for (const amountDue of billingResults.dueAmounts) {
+      messages.push(
+        `${amountDue.builder} was billed ${ethers.formatEther(
+          amountDue.dueAmountWei,
+        )} ETH`,
+      );
+    }
+    await this.slack.post(messages.join("\n"));
   }
 
   async runDrafting() {

--- a/src/dune.ts
+++ b/src/dune.ts
@@ -29,7 +29,7 @@ export class QueryRunner {
     billingQuery: number,
     paymentQuery: number,
     feeQuery: number,
-    options?: RuntimeOptions
+    options?: RuntimeOptions,
   ) {
     this.dune = new DuneClient(apiKey);
     this.billingQuery = billingQuery;
@@ -53,7 +53,7 @@ export class QueryRunner {
       parseInt(BILLING_QUERY!),
       parseInt(PAYMENT_QUERY!),
       parseInt(FEE_QUERY!),
-      options
+      options,
     );
   }
 

--- a/src/dune.ts
+++ b/src/dune.ts
@@ -29,7 +29,7 @@ export class QueryRunner {
     billingQuery: number,
     paymentQuery: number,
     feeQuery: number,
-    options?: RuntimeOptions,
+    options?: RuntimeOptions
   ) {
     this.dune = new DuneClient(apiKey);
     this.billingQuery = billingQuery;
@@ -53,7 +53,7 @@ export class QueryRunner {
       parseInt(BILLING_QUERY!),
       parseInt(PAYMENT_QUERY!),
       parseInt(FEE_QUERY!),
-      options,
+      options
     );
   }
 
@@ -68,6 +68,7 @@ export class QueryRunner {
       console.log("Got Billing Results:", results);
       return results.map((row: any) => ({
         billingAddress: row.miner_biller_address!,
+        builder: row.miner_label,
         dueAmountWei: BigInt(row.amount_due_wei!),
       }));
     } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface AmountDue {
   billingAddress: `0x${string}`;
+  builder?: string;
   dueAmountWei: bigint;
 }
 


### PR DESCRIPTION
Currently, the only thing the slack notification contains is a link to the transaction (making it difficult to understand how much each biller was billed in absolute terms).

This PR improves the message to contain for each builder label the amount formatted to whole ETH units.

### Test Plan

Run on Sepolia, see
> MEV Billing ran successfully: undefined/tx/0x3ab282f6310c85f99601c0ed2d6dca7dfcc6302ed7dbe296fa3682b9daffa6c4
beaverbuild was billed 15.436981310089693184 ETH
Titan was billed 11.548833220606410752 ETH
rsync-builder was billed 1.663119822328813056 ETH
Flashbots was billed 0.708521337900857472 ETH