### PR TITLE
[Hotfix] Fix computation period of the fee for billing

### DIFF
--- a/src/dune.ts
+++ b/src/dune.ts
@@ -111,6 +111,18 @@ export class QueryRunner {
   async getBillingData(date: Date): Promise<BillingData> {
     try {
       const billingDate = moment(date).format("YYYY-MM-DD 00:00:00");
+      // The fee for the current period is the per block fee of the starting date (computed over the previous month)
+      const billingFeeComputationStart = moment(date)
+        .subtract(7, "day")
+        .subtract(1, "month")
+        .startOf("month")
+        .format("YYYY-MM-DD 00:00:00");
+      const billingFeeComputationEnd = moment(date)
+        .subtract(7, "day")
+        .startOf("month")
+        .format("YYYY-MM-DD 00:00:00");
+
+      // The fee for the next period is the fee of the previous month
       const feeComputationStart = moment(date)
         .subtract(1, "month")
         .startOf("month")
@@ -120,7 +132,11 @@ export class QueryRunner {
         .format("YYYY-MM-DD 00:00:00");
       console.log(`Executing fee and payment queries this may take a while...`);
       const [dueAmounts, periodFee] = await Promise.all([
-        this.getAmountsDue(billingDate, feeComputationStart, feeComputationEnd),
+        this.getAmountsDue(
+          billingDate,
+          billingFeeComputationStart,
+          billingFeeComputationEnd,
+        ),
         this.getPeriodFee(feeComputationStart, feeComputationEnd),
       ]);
       return { dueAmounts, periodFee };


### PR DESCRIPTION
The billing query ran today with the incorrect per block fee. The reason is that we used the September fee (computed over August) as a basis. However, today's billing period started in August so the August fee (computed over July) should have been used.

At the same time we need to post the new period's fee (since we are in September computed over August).

This PR fixes this by differentiating between the `billingFeeComputationPeriod` (based on current day - 1 week) and the new `feeComputationPeriod`

## Test Plan

Ran on sepolia: https://sepolia.etherscan.io/tx/0x0acfd563f283befb5376ae545689801d20c246a4a7b4768dfb583dd14211ff33#eventlog